### PR TITLE
fix #3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ResistanceGA
 Title: Optimize resistance surfaces using genetic algorithms
-Version: 3.0-2
+Version: 3.0-3
 Author: Bill Peterman <Bill.Peterman@gmail.com>
 Maintainer: Bill Peterman <bill.peterman@gmail.com>
 Description: This package contains functions to optimize

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+ResistanceGA 3.0-3
+--------
+* Fix issue in SCALE returning infinite values (#3).
+
 ResistanceGA 3.0-1
 --------
 * The fitted, optimized MLPE mixed effects models are now saved with the output of the model runs.
@@ -77,11 +81,11 @@ ResistanceGA 2.0-11
 
 ResistanceGA 2.0-10
 --------
-* Updated CS.prep error message 
+* Updated CS.prep error message
 
 ResistanceGA 2.0-9
 --------
-* Fixed error in Diagnostic.Plot 
+* Fixed error in Diagnostic.Plot
 * Cleaned and consolodated code for conducting raster transformations
 * Added functionality to use the advanced CIRCUITSCAPE feature of "pairs_to_include". This is not yet well documented, so contact me directly if you have interest in using this feature.
 
@@ -115,7 +119,7 @@ ResistanceGA 2.0-3
 
 ResistanceGA 2.0-2
 ---------
-* Have tested and added the option to run optimization in parallel when using least cost paths. Set `parallel= TRUE` or `parallel = #cores` in `GA.prep`   
+* Have tested and added the option to run optimization in parallel when using least cost paths. Set `parallel= TRUE` or `parallel = #cores` in `GA.prep`
 * PARALLEL DOES NOT CURRENTLY WORK WHEN OPTIMIZING WITH CIRCUITSCAPE!!!
 
 ResistanceGA 2.0-1

--- a/R/internal_helper_functions.R
+++ b/R/internal_helper_functions.R
@@ -262,20 +262,29 @@ ZZ.mat <- function(ID) {
   return(ZZ)
 }
 
-
 # Rescale function
-SCALE.vector <- function(data, MIN, MAX) {
-  Mn = min(data)
-  Mx = max(data)
-  (MAX - MIN) / (Mx - Mn) * (data - Mx) + MAX
+SCALE.vector <- function(data, MIN, MAX, threshold = 1e-5) {
+  if (abs(MIN - MAX) < threshold) {
+    data[is.finite(data)] <- 0
+    data
+  } else {
+    Mn = min(data)
+    Mx = max(data)
+    (MAX - MIN) / (Mx - Mn) * (data - Mx) + MAX
+  }
 }
 
 # Define scaling function
 # This will rescale from 1 to specified MAX
-SCALE <- function(data, MIN, MAX) {
-  Mn = cellStats(data, stat = 'min')
-  Mx = cellStats(data, stat = 'max')
-  (MAX - MIN) / (Mx - Mn) * (data - Mx) + MAX
+SCALE <- function(data, MIN, MAX, threshold = 1e-5) {
+  if (abs(MIN - MAX) < threshold) {
+    data[is.finite(raster::values(data))] <- 0
+    data
+  } else {
+    Mn = cellStats(data, stat = 'min')
+    Mx = cellStats(data, stat = 'max')
+    (MAX - MIN) / (Mx - Mn) * (data - Mx) + MAX
+  }
 }
 
 # Sample values for suggests


### PR DESCRIPTION
I've included the definitions for `SCALE` and `SCALE.vector` mentioned in #3. 

I've also updated DESCRIPTION with a new patch number (3.0-3), and added an entry to NEWS describing the patch.

I wasn't paying attention and my text editor also automatically removed the extra spaces in NEWS (lines 80, 84, 118, 155). If this is an issue, I can refork your repo and make the changes again in a different editor so the extra spaces are still in.
