### PR TITLE
Fix handling of 'precision' option for Circuitscape.jl

### DIFF
--- a/R/write_CS_file.R
+++ b/R/write_CS_file.R
@@ -33,11 +33,10 @@ write.CS_4.0 <- function(BATCH,
     LOG <- "log_level = INFO"
   }
   
-  if(precision=='none') {
-    precision <- "precision = None"
-  } else if (precision=='single') {
+  if(isTRUE(precision)) {
     precision <- "precision = single"
   } else {
+    # double precision is the default in Cicuitscape.jl
     precision <- ""
   }
   

--- a/R/write_CS_file.R
+++ b/R/write_CS_file.R
@@ -33,13 +33,13 @@ write.CS_4.0 <- function(BATCH,
     LOG <- "log_level = INFO"
   }
   
-  if(!isTRUE(precision)) {
+  if(precision=='none') {
     precision <- "precision = None"
-  }
-  
-  if(precision == 'single') {
+  } else if (precision=='single') {
     precision <- "precision = single"
-  } 
+  } else {
+    precision <- ""
+  }
   
   if(isTRUE(is_resistance)) {
     RESISTANCE <- "connect_using_avg_resistances = False"


### PR DESCRIPTION
Currently, it is impossible to invoke the single precision option of Circuitscape.jl from ResistanceGA following the documentation's guidance. When the value of precision is FALSE, "precision = None" is added to the .ini file. Circuitscape then reports "Precision: None", but I think it uses the default double precision. When the value of precision is TRUE, the option doesn't get added to the .ini file because the if-statement is testing "if(precision == 'single')". This pull request fixes that handling so that the single precision option can be invoked.

(I should have used a branch, but I so very rarely use git that I had forgot about that aspect of it. I can re-fork and create the change in a branch if you'd prefer.)